### PR TITLE
I've made a fix to implement giscus comments via theme extension.

### DIFF
--- a/check_giscus.py
+++ b/check_giscus.py
@@ -1,0 +1,64 @@
+import asyncio
+from playwright.async_api import async_playwright, ConsoleMessage, Request
+
+async def handle_console_message(msg: ConsoleMessage):
+    try:
+        print(f"CONSOLE ({msg.type()}): {msg.text()}")
+    except Exception as e:
+        print(f"Error in handle_console_message: {e}")
+        # Fallback to inspect the object if methods fail
+        print(f"ConsoleMessage object: type={type(msg)}, dir={dir(msg)}")
+        if hasattr(msg, '_initializer'):
+             print(f"ConsoleMessage initializer: {msg._initializer}")
+
+
+async def handle_request_failed(request: Request):
+    try:
+        failure = request.failure()
+        error_text = failure.error_text if failure else "N/A"
+        print(f"REQUEST_FAILED: {request.url()} - {error_text}")
+    except Exception as e:
+        print(f"Error in handle_request_failed: {e}")
+        # Fallback to inspect the object
+        print(f"Request object: type={type(request)}, dir={dir(request)}")
+        if hasattr(request, '_initializer'):
+            print(f"Request initializer: {request._initializer}")
+
+
+async def main():
+    print("Starting Playwright script...")
+    async with async_playwright() as p:
+        browser = None 
+        try:
+            print("Launching browser...")
+            browser = await p.chromium.launch()
+            print("Browser launched.")
+            page = await browser.new_page()
+            print("New page created.")
+
+            # Updated event handling
+            page.on("console", lambda msg: asyncio.create_task(handle_console_message(msg)))
+            page.on("requestfailed", lambda req: asyncio.create_task(handle_request_failed(req)))
+
+            file_path = "file:///app/site/blog/2024/09/25/i-passed-the-cissp-exam/index.html"
+            print(f"Navigating to {file_path}...")
+
+            await page.goto(file_path, wait_until="networkidle", timeout=20000)
+            print("Page navigation complete (networkidle).")
+            
+            print("Waiting for additional 10 seconds for async operations (giscus)...")
+            await page.wait_for_timeout(10000) 
+            print("Finished waiting.")
+
+        except Exception as e:
+            print(f"An error occurred in main: {e}")
+        finally:
+            if browser:
+                print("Closing browser...")
+                await browser.close()
+                print("Browser closed.")
+            else:
+                print("Browser was not launched, no need to close.")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ site_url: https://cinnak.github.io/cinnakblog/
 
 theme:
   name: material
+  custom_dir: 'overrides'
   language: en
   features:
     - navigation.tabs
@@ -28,19 +29,19 @@ theme:
         name: Switch to light mode
 
 # Add the extra section for Giscus configuration
-extra:
-  comments:
-    provider: giscus
-    repo: cinnak/cinnakblog
-    repo_id: R_kgDOODT1GA
-    category: Announcements
-    category_id: DIC_kwDOODT1GM4Co7OO
-    mapping: pathname
-    reactions_enabled: '1' # Keep as string if required by the theme
-    emit_metadata: '0'  # Keep as string if required by the theme
-    input_position: bottom
-    theme: preferred_color_scheme
-    lang: en
+# extra:
+#   comments:
+#     provider: giscus
+#     repo: cinnak/cinnakblog
+#     repo_id: R_kgDOODT1GA
+#     category: Announcements
+#     category_id: DIC_kwDOODT1GM4Co7OO
+#     mapping: pathname
+#     reactions_enabled: '1' # Keep as string if required by the theme
+#     emit_metadata: '0'  # Keep as string if required by the theme
+#     input_position: bottom
+#     theme: preferred_color_scheme
+#     lang: en
 
 nav:
   - Home: index.md

--- a/overrides/partials/comments.html
+++ b/overrides/partials/comments.html
@@ -1,0 +1,58 @@
+{% if page.meta.comments %}
+  <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
+  <!-- Giscus script tag -->
+  <script src="https://giscus.app/client.js"
+          data-repo="cinnak/cinnakblog"
+          data-repo-id="R_kgDOODT1GA"
+          data-category="Announcements"
+          data-category-id="DIC_kwDOODT1GM4Co7OO"
+          data-mapping="pathname"
+          data-strict="0"
+          data-reactions-enabled="1"
+          data-emit-metadata="0"
+          data-input-position="bottom"
+          data-theme="preferred_color_scheme"
+          data-lang="en"
+          crossorigin="anonymous"
+          async>
+  </script>
+  <!-- End Giscus script tag -->
+
+  <!-- Synchronize Giscus theme with palette -->
+  <script>
+    var giscus = document.querySelector("script[src*=giscus]")
+
+    // Set palette on initial load
+    var palette = __md_get("__palette")
+    if (palette && typeof palette.color === "object") {
+      var theme = palette.color.scheme === "slate"
+        ? "transparent_dark"
+        : "light"
+
+      // Instruct Giscus to set theme
+      giscus.setAttribute("data-theme", theme)
+    }
+
+    // Register event handlers after documented loaded
+    document.addEventListener("DOMContentLoaded", function() {
+      var ref = document.querySelector("[data-md-component=palette]")
+      ref.addEventListener("change", function() {
+        var palette = __md_get("__palette")
+        if (palette && typeof palette.color === "object") {
+          var theme = palette.color.scheme === "slate"
+            ? "transparent_dark"
+            : "light"
+
+          // Instruct Giscus to change theme
+          var frame = document.querySelector(".giscus-frame")
+          if (frame) { // Check if giscus frame exists
+            frame.contentWindow.postMessage(
+              { giscus: { setConfig: { theme } } },
+              "https://giscus.app"
+            )
+          }
+        }
+      })
+    })
+  </script>
+{% endif %}


### PR DESCRIPTION
I switched the giscus integration from `extra.comments` configuration to the Material for MkDocs recommended theme extension method using a custom `overrides/partials/comments.html` file.

This change involves:
- Creating `overrides/partials/comments.html` with the giscus script tag and theme synchronization logic.
- Updating `mkdocs.yml` to include `custom_dir: 'overrides'` under the theme settings.
- Commenting out the previous `extra.comments` giscus configuration in `mkdocs.yml` to prevent conflicts.

This aligns the implementation with the official Material for MkDocs documentation for giscus and is expected to resolve issues where the comment section was not appearing.