### PR TITLE
Feat: Enable comments on all blog posts

### DIFF
--- a/docs/blog/posts/I passed CISSP exam.md
+++ b/docs/blog/posts/I passed CISSP exam.md
@@ -7,6 +7,7 @@ categories:
 description: My experience and tips for passing the CISSP exam
 tags:
     - CISSP
+comments: true
 ---
 # I Passed the CISSP Exam 
 I passed the CISSP exam on 10th Sept after a year of studying, with just under 110 questions on the exam. I'd love to share my experience, the resources I found valuable, and some tips that might help you on your journey.

--- a/docs/blog/posts/Lessons from Chip Huyen_Mastering ML Interviews and Career Strategies.md
+++ b/docs/blog/posts/Lessons from Chip Huyen_Mastering ML Interviews and Career Strategies.md
@@ -9,6 +9,7 @@ categories:
 tags:
   - Reading
   - Career
+comments: true
 ---
 I've read Chip Huyen's [Introduction to Machine Learning Interviews Book](https://huyenchip.com/ml-interviews-book/), but not the whole thing since I skipped most of the Part II questions. The book includes so many sincere tips, fabulous learning resource recommendations, and so much real-life experience from Chip herself, her friends, and the people she interviewed.
 <!-- more -->

--- a/docs/blog/posts/Optimizing My Life with Huberman Lab.md
+++ b/docs/blog/posts/Optimizing My Life with Huberman Lab.md
@@ -7,6 +7,7 @@ categories:
 description: Optimizing My Life with Huberman Lab
 tags:
   - Life
+comments: true
 ---
 **TL;DR: Key Huberman Protocols & My Results**
 

--- a/docs/blog/posts/The Twin Engines of Learning.md
+++ b/docs/blog/posts/The Twin Engines of Learning.md
@@ -9,6 +9,7 @@ description:
 tags:
   - Learning
   - IELTS
+comments: true
 ---
 I'm exploring Scott Young's 'twin engines' of learning – combining foundational principles (_Get Better at Anything_) with actionable strategies (_Ultralearning_) – on my own six-month IELTS quest.
 <!-- more -->

--- a/docs/blog/posts/When Smart Books Say Nothing - A Postmortem of Building AI-Powered Products.md
+++ b/docs/blog/posts/When Smart Books Say Nothing - A Postmortem of Building AI-Powered Products.md
@@ -8,6 +8,7 @@ categories:
 description: A Postmortem of *Building AI-Powered Products
 tags:
   - Reading
+comments: true
 ---
 
 # When Smart Books Say Nothing: A Postmortem of *Building AI-Powered Products*


### PR DESCRIPTION
I've added `comments: true` to the frontmatter of all existing blog posts in the `docs/blog/posts/` directory.

This ensures that the giscus comment section is displayed on each post, as the `partials/comments.html` template relies on `page.meta.comments` being true. I took this step after my investigation revealed that the global `.meta.yml` setting for comments was not being applied to individual blog posts.